### PR TITLE
Fix dispose, memory leaks y widgets const

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -21,26 +21,26 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.4.0"
   clock:
     dependency: transitive
     description:
       name: clock
-      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   collection:
     dependency: transitive
     description:
       name: collection
-      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
+      sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.1"
+    version: "1.19.1"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -53,10 +53,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.3"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -75,14 +75,30 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  js:
+  leak_tracker:
     dependency: transitive
     description:
-      name: js
-      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
+      name: leak_tracker
+      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.7"
+    version: "11.0.2"
+  leak_tracker_flutter_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_flutter_testing
+      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.10"
+  leak_tracker_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_testing
+      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.2"
   lints:
     dependency: transitive
     description:
@@ -95,26 +111,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "6501fbd55da300384b768785b83e5ce66991266cec21af89ab9ae7f5ce1c4cbb"
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.15"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.17.0"
   occam:
     dependency: "direct main"
     description:
@@ -126,15 +142,15 @@ packages:
     dependency: transitive
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
+    version: "1.9.1"
   sky_engine:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.99"
+    version: "0.0.0"
   source_span:
     dependency: transitive
     description:
@@ -147,18 +163,18 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      sha256: "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.12.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      sha256: "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.4"
   string_scanner:
     dependency: transitive
     description:
@@ -179,17 +195,26 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: eb6ac1540b26de412b3403a163d919ba86f6a973fe6cc50ae3541b80092fdcfb
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.1"
+    version: "0.7.7"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
+  vm_service:
+    dependency: transitive
+    description:
+      name: vm_service
+      sha256: "45caa6c5917fa127b5dbcfbd1fa60b14e583afdc08bfc96dda38886ca252eb60"
+      url: "https://pub.dev"
+    source: hosted
+    version: "15.0.2"
 sdks:
-  dart: ">=3.0.0 <4.0.0"
+  dart: ">=3.8.0-0 <4.0.0"
+  flutter: ">=3.18.0-18.0.pre.54"

--- a/lib/src/lyfe_cicle/state_parent.dart
+++ b/lib/src/lyfe_cicle/state_parent.dart
@@ -44,14 +44,17 @@ class ParentStateElement<T extends StateController> extends StatelessElement {
 
   @override
   void unmount() {
+    StateElement._elements[widget] = null;
     _justMounted = false;
     super.unmount();
   }
 
   @override
   void update(StatelessWidget newWidget) {
+    final oldWidget = widget;
     StateElement._elements[newWidget] = this;
     super.update(newWidget);
+    StateElement._elements[oldWidget] = null;
   }
 
   T findStateControllerProvider() {

--- a/lib/src/lyfe_cicle/state_widget.dart
+++ b/lib/src/lyfe_cicle/state_widget.dart
@@ -7,8 +7,10 @@ abstract class StateWidget<T extends State> extends StatefulWidget {
 
   T get state {
     final fromStack = StateElement._stateFromBuildStack(this);
+    print("fromStack: ${fromStack.hashCode}");
     if (fromStack != null) return fromStack as T;
     final fromRegistry = StateElement._stateFromRegistry(this);
+    print("fromRegistry: ${fromRegistry.hashCode}");
     if (fromRegistry != null) return fromRegistry as T;
     throw FlutterError(
       'StateWidget.state was accessed but the controller is not available. '
@@ -26,7 +28,9 @@ abstract class StateWidget<T extends State> extends StatefulWidget {
 
 class StateElement extends StatefulElement {
   static final _elements = Expando('State Controllers');
-  static final List<StateElement> _buildStack = [];
+
+  /// Stack of currently building elements per widget (supports nested same-widget).
+  static final Map<StateWidget, List<StateElement>> _buildStackByWidget = {};
   static final Set<StateElement> _mountedStateElements = {};
 
   bool _justMounted = true;
@@ -37,6 +41,8 @@ class StateElement extends StatefulElement {
   void mount(Element? parent, Object? newSlot) {
     _justMounted = true;
     _mountedStateElements.add(this);
+    print("mount: $hashCode");
+    print("mount _mountedStateElements length: ${_mountedStateElements.length}");
     super.mount(parent, newSlot);
   }
 
@@ -44,6 +50,9 @@ class StateElement extends StatefulElement {
   void unmount() {
     _mountedStateElements.remove(this);
     _justMounted = false;
+    print("unmount: $hashCode");
+    print("unmount _mountedStateElements length: ${_mountedStateElements.length}");
+    print("unmount _buildStackByWidget length: ${_buildStackByWidget.length}");
     super.unmount();
   }
 
@@ -66,22 +75,21 @@ class StateElement extends StatefulElement {
 
   @override
   Widget build() {
-    _buildStack.add(this);
+    final w = widget;
+    (_buildStackByWidget[w] ??= []).add(this);
     try {
       return widget.build(this);
     } finally {
-      _buildStack.removeLast();
+      final list = _buildStackByWidget[w]!;
+      list.removeLast();
+      if (list.isEmpty) _buildStackByWidget.remove(w);
     }
   }
 
   static State? _stateFromBuildStack(StateWidget widget) {
-    for (var i = _buildStack.length - 1; i >= 0; i--) {
-      final element = _buildStack[i];
-      if (identical(element.widget, widget)) {
-        return element.state;
-      }
-    }
-    return null;
+    final list = _buildStackByWidget[widget];
+    if (list == null || list.isEmpty) return null;
+    return list.last.state;
   }
 
   /// Fallback when stack is empty (e.g. child rebuild). Keys by element, not

--- a/lib/src/lyfe_cicle/state_widget.dart
+++ b/lib/src/lyfe_cicle/state_widget.dart
@@ -7,10 +7,8 @@ abstract class StateWidget<T extends State> extends StatefulWidget {
 
   T get state {
     final fromStack = StateElement._stateFromBuildStack(this);
-    print("fromStack: ${fromStack.hashCode}");
     if (fromStack != null) return fromStack as T;
     final fromRegistry = StateElement._stateFromRegistry(this);
-    print("fromRegistry: ${fromRegistry.hashCode}");
     if (fromRegistry != null) return fromRegistry as T;
     throw FlutterError(
       'StateWidget.state was accessed but the controller is not available. '
@@ -41,8 +39,6 @@ class StateElement extends StatefulElement {
   void mount(Element? parent, Object? newSlot) {
     _justMounted = true;
     _mountedStateElements.add(this);
-    print("mount: $hashCode");
-    print("mount _mountedStateElements length: ${_mountedStateElements.length}");
     super.mount(parent, newSlot);
   }
 
@@ -50,9 +46,6 @@ class StateElement extends StatefulElement {
   void unmount() {
     _mountedStateElements.remove(this);
     _justMounted = false;
-    print("unmount: $hashCode");
-    print("unmount _mountedStateElements length: ${_mountedStateElements.length}");
-    print("unmount _buildStackByWidget length: ${_buildStackByWidget.length}");
     super.unmount();
   }
 

--- a/lib/src/lyfe_cicle/state_widget.dart
+++ b/lib/src/lyfe_cicle/state_widget.dart
@@ -8,26 +8,13 @@ abstract class StateWidget<T extends State> extends StatefulWidget {
   T get state {
     final fromStack = StateElement._stateFromBuildStack(this);
     if (fromStack != null) return fromStack as T;
-    final value = StateElement._elements[this];
-    if (value == null) {
-      throw FlutterError(
-        'StateWidget.state was accessed but the controller is not available. '
-        'Access state only from within build(BuildContext context), or the '
-        'widget may have been unmounted.',
-      );
-    }
-    // Lazy cleanup: don't return a disposed state (e.g. after one of several
-    // const widgets unmounted and we didn't clear the shared key).
-    final stateValue = value as State;
-    if (!stateValue.mounted) {
-      StateElement._elements[this] = null;
-      throw FlutterError(
-        'StateWidget.state was accessed but the controller is not available. '
-        'Access state only from within build(BuildContext context), or the '
-        'widget may have been unmounted.',
-      );
-    }
-    return value as T;
+    final fromRegistry = StateElement._stateFromRegistry(this);
+    if (fromRegistry != null) return fromRegistry as T;
+    throw FlutterError(
+      'StateWidget.state was accessed but the controller is not available. '
+      'Access state only from within build(BuildContext context), or the '
+      'widget may have been unmounted.',
+    );
   }
 
   @override
@@ -40,34 +27,29 @@ abstract class StateWidget<T extends State> extends StatefulWidget {
 class StateElement extends StatefulElement {
   static final _elements = Expando('State Controllers');
   static final List<StateElement> _buildStack = [];
+  static final Set<StateElement> _mountedStateElements = {};
 
   bool _justMounted = true;
 
-  StateElement(StateWidget widget) : super(widget) {
-    _elements[widget] = state;
-  }
+  StateElement(StateWidget widget) : super(widget) {}
 
   @override
   void mount(Element? parent, Object? newSlot) {
     _justMounted = true;
+    _mountedStateElements.add(this);
     super.mount(parent, newSlot);
   }
 
   @override
   void unmount() {
-    // Do not clear _elements[widget] here: with const widgets several elements
-    // share the same widget instance; clearing would break the others. Stale
-    // entries are cleared lazily when read (see state getter).
+    _mountedStateElements.remove(this);
     _justMounted = false;
     super.unmount();
   }
 
   @override
   void update(StatefulWidget newWidget) {
-    final oldWidget = widget;
-    _elements[newWidget] = state;
     super.update(newWidget);
-    _elements[oldWidget] = null;
   }
 
   @override
@@ -104,6 +86,17 @@ class StateElement extends StatefulElement {
     for (var i = _buildStack.length - 1; i >= 0; i--) {
       final element = _buildStack[i];
       if (identical(element.widget, widget)) {
+        return element.state;
+      }
+    }
+    return null;
+  }
+
+  /// Fallback when stack is empty (e.g. child rebuild). Keys by element, not
+  /// widget, so unmount only removes this element and does not affect others.
+  static State? _stateFromRegistry(StateWidget widget) {
+    for (final element in _mountedStateElements) {
+      if (element.mounted && identical(element.widget, widget)) {
         return element.state;
       }
     }

--- a/lib/src/lyfe_cicle/state_widget.dart
+++ b/lib/src/lyfe_cicle/state_widget.dart
@@ -31,7 +31,7 @@ class StateElement extends StatefulElement {
 
   bool _justMounted = true;
 
-  StateElement(StateWidget widget) : super(widget) {}
+  StateElement(StateWidget widget) : super(widget);
 
   @override
   void mount(Element? parent, Object? newSlot) {
@@ -45,11 +45,6 @@ class StateElement extends StatefulElement {
     _mountedStateElements.remove(this);
     _justMounted = false;
     super.unmount();
-  }
-
-  @override
-  void update(StatefulWidget newWidget) {
-    super.update(newWidget);
   }
 
   @override
@@ -75,10 +70,7 @@ class StateElement extends StatefulElement {
     try {
       return widget.build(this);
     } finally {
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        final i = _buildStack.lastIndexOf(this);
-        if (i != -1) _buildStack.removeAt(i);
-      });
+      _buildStack.removeLast();
     }
   }
 

--- a/lib/src/lyfe_cicle/state_widget.dart
+++ b/lib/src/lyfe_cicle/state_widget.dart
@@ -16,6 +16,17 @@ abstract class StateWidget<T extends State> extends StatefulWidget {
         'widget may have been unmounted.',
       );
     }
+    // Lazy cleanup: don't return a disposed state (e.g. after one of several
+    // const widgets unmounted and we didn't clear the shared key).
+    final stateValue = value as State;
+    if (!stateValue.mounted) {
+      StateElement._elements[this] = null;
+      throw FlutterError(
+        'StateWidget.state was accessed but the controller is not available. '
+        'Access state only from within build(BuildContext context), or the '
+        'widget may have been unmounted.',
+      );
+    }
     return value as T;
   }
 
@@ -44,7 +55,9 @@ class StateElement extends StatefulElement {
 
   @override
   void unmount() {
-    _elements[widget] = null;
+    // Do not clear _elements[widget] here: with const widgets several elements
+    // share the same widget instance; clearing would break the others. Stale
+    // entries are cleared lazily when read (see state getter).
     _justMounted = false;
     super.unmount();
   }

--- a/lib/src/lyfe_cicle/state_widget.dart
+++ b/lib/src/lyfe_cicle/state_widget.dart
@@ -5,7 +5,19 @@ abstract class StateWidget<T extends State> extends StatefulWidget {
 
   Widget build(BuildContext context);
 
-  T get state => StateElement._elements[this] as T;
+  T get state {
+    final fromStack = StateElement._stateFromBuildStack(this);
+    if (fromStack != null) return fromStack as T;
+    final value = StateElement._elements[this];
+    if (value == null) {
+      throw FlutterError(
+        'StateWidget.state was accessed but the controller is not available. '
+        'Access state only from within build(BuildContext context), or the '
+        'widget may have been unmounted.',
+      );
+    }
+    return value as T;
+  }
 
   @override
   StateElement createElement() => StateElement(this);
@@ -16,6 +28,7 @@ abstract class StateWidget<T extends State> extends StatefulWidget {
 
 class StateElement extends StatefulElement {
   static final _elements = Expando('State Controllers');
+  static final List<StateElement> _buildStack = [];
 
   bool _justMounted = true;
 
@@ -31,14 +44,17 @@ class StateElement extends StatefulElement {
 
   @override
   void unmount() {
+    _elements[widget] = null;
     _justMounted = false;
     super.unmount();
   }
 
   @override
   void update(StatefulWidget newWidget) {
+    final oldWidget = widget;
     _elements[newWidget] = state;
     super.update(newWidget);
+    _elements[oldWidget] = null;
   }
 
   @override
@@ -59,5 +75,22 @@ class StateElement extends StatefulElement {
   StateWidget get widget => super.widget as StateWidget;
 
   @override
-  Widget build() => widget.build(this);
+  Widget build() {
+    _buildStack.add(this);
+    try {
+      return widget.build(this);
+    } finally {
+      _buildStack.removeLast();
+    }
+  }
+
+  static State? _stateFromBuildStack(StateWidget widget) {
+    for (var i = _buildStack.length - 1; i >= 0; i--) {
+      final element = _buildStack[i];
+      if (identical(element.widget, widget)) {
+        return element.state;
+      }
+    }
+    return null;
+  }
 }

--- a/lib/src/lyfe_cicle/state_widget.dart
+++ b/lib/src/lyfe_cicle/state_widget.dart
@@ -80,7 +80,10 @@ class StateElement extends StatefulElement {
     try {
       return widget.build(this);
     } finally {
-      _buildStack.removeLast();
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        final i = _buildStack.lastIndexOf(this);
+        if (i != -1) _buildStack.removeAt(i);
+      });
     }
   }
 

--- a/lib/src/rx/rx_notifier.dart
+++ b/lib/src/rx/rx_notifier.dart
@@ -1,11 +1,11 @@
 part of occam;
 
 abstract class RxInterface<T> extends ValueNotifier<T> with RxMixin<T> {
-  RxInterface(T value) : super(value);
+  RxInterface(super.value);
 }
 
 class Rx<T> extends RxInterface<T> {
-  Rx(T value) : super(value);
+  Rx(super.value);
 }
 
 mixin RxMixin<T> on ValueNotifier<T> {
@@ -61,36 +61,35 @@ mixin RxMixin<T> on ValueNotifier<T> {
     return true;
   }
 
-  FutureOr closeStream(Stream<T> stream) {
-    if (_subscriptions.containsKey(stream)) {
-      return _subscriptions.remove(stream)!.cancel();
-    }
+  Future<void>? closeStream(Stream<T> stream) {
+    return _subscriptions.remove(stream)?.cancel();
   }
 
   void bindStream(Stream<T> stream) {
+    closeStream(stream);
+
     late StreamSubscription subscription;
+
     subscription = stream.asBroadcastStream().listen(
       (event) => value = event,
       onDone: () {
         subscription.cancel();
-        _subscriptions.remove(subscription);
+        _subscriptions.remove(stream);
       },
     );
+
     _subscriptions[stream] = subscription;
   }
 
   /// To prevent potential thrown exceptions.
   bool _disposed = false;
 
-  @override
-  bool get hasListeners => _listeners.isNotEmpty;
-
   bool get disposed => _disposed;
 
   @override
   void dispose() {
     _disposed = true;
-    for (final listener in _listeners) {
+    for (final listener in List<VoidCallback>.from(_listeners)) {
       removeListener(listener);
     }
     for (final subscription in _subscriptions.values) {

--- a/lib/src/widgets/rx_widget.dart
+++ b/lib/src/widgets/rx_widget.dart
@@ -26,8 +26,11 @@ class _RxWidgetState<T> extends State<RxWidget<T>> {
 
   @override
   void didUpdateWidget(RxWidget<T> oldWidget) {
-    if (oldWidget.notifier.value != widget.notifier.value) {
+    if (oldWidget.notifier != widget.notifier) {
       oldWidget.notifier.removeListener(_update);
+      widget.notifier.addListener(_update);
+      value = widget.notifier.value;
+    } else if (oldWidget.notifier.value != widget.notifier.value) {
       value = widget.notifier.value;
     }
     super.didUpdateWidget(oldWidget);

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -109,10 +109,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.4.0"
   checked_yaml:
     dependency: transitive
     description:
@@ -125,10 +125,10 @@ packages:
     dependency: transitive
     description:
       name: clock
-      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   code_builder:
     dependency: transitive
     description:
@@ -141,10 +141,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
+      sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.1"
+    version: "1.19.1"
   convert:
     dependency: transitive
     description:
@@ -173,10 +173,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.3"
   file:
     dependency: transitive
     description:
@@ -275,6 +275,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.8.1"
+  leak_tracker:
+    dependency: transitive
+    description:
+      name: leak_tracker
+      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
+      url: "https://pub.dev"
+    source: hosted
+    version: "11.0.2"
+  leak_tracker_flutter_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_flutter_testing
+      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.10"
+  leak_tracker_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_testing
+      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.2"
   lints:
     dependency: transitive
     description:
@@ -295,26 +319,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "6501fbd55da300384b768785b83e5ce66991266cec21af89ab9ae7f5ce1c4cbb"
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.15"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.11.1"
   meta:
     dependency: "direct main"
     description:
       name: meta
-      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -327,10 +351,10 @@ packages:
     dependency: "direct dev"
     description:
       name: mockito
-      sha256: "7d5b53bcd556c1bc7ffbe4e4d5a19c3e112b7e925e9e172dd7c6ad0630812616"
+      sha256: "6841eed20a7befac0ce07df8116c8b8233ed1f4486a7647c7fc5a02ae6163917"
       url: "https://pub.dev"
     source: hosted
-    version: "5.4.2"
+    version: "5.4.4"
   package_config:
     dependency: transitive
     description:
@@ -343,10 +367,10 @@ packages:
     dependency: transitive
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
+    version: "1.9.1"
   pool:
     dependency: transitive
     description:
@@ -391,7 +415,7 @@ packages:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.99"
+    version: "0.0.0"
   source_gen:
     dependency: transitive
     description:
@@ -412,18 +436,18 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      sha256: "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.12.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      sha256: "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.4"
   stream_transform:
     dependency: transitive
     description:
@@ -452,10 +476,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: eb6ac1540b26de412b3403a163d919ba86f6a973fe6cc50ae3541b80092fdcfb
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.1"
+    version: "0.7.7"
   test_cov_console:
     dependency: "direct dev"
     description:
@@ -484,10 +508,18 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
+  vm_service:
+    dependency: transitive
+    description:
+      name: vm_service
+      sha256: "45caa6c5917fa127b5dbcfbd1fa60b14e583afdc08bfc96dda38886ca252eb60"
+      url: "https://pub.dev"
+    source: hosted
+    version: "15.0.2"
   watcher:
     dependency: transitive
     description:
@@ -513,4 +545,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.0.0 <4.0.0"
+  dart: ">=3.8.0-0 <4.0.0"
+  flutter: ">=3.18.0-18.0.pre.54"


### PR DESCRIPTION
## Fix dispose, memory leaks y resolución de `state` con widgets const
### Problema
1. **StateWidget y Expando por widget**  
   El controller se resolvía con un Expando con una key por **widget**. Con widgets `const`, varias instancias comparten el mismo widget. Si en `unmount()` se hacía `_elements[widget] = null`, se borraba la entrada para **todos** los que usaban ese widget y el resto fallaba al leer `state`. Si no se limpiaba para evitar eso, quedaban referencias (del widget al State) sin liberar, lo que producía un **memory leak**.
2. **StateElement.update()**  
   Se limpiaba la entrada del widget viejo **antes** de `super.update()`, así que en rebuilds síncronos el elemento podía seguir usando el widget viejo y encontrar `null` provocando crash del cast del state.
3. **ParentStateElement**  
   No se limpiaba el Expando en `unmount` ni la entrada del widget viejo en `update` provocando acumulación de entradas y posibles leaks.
4. **RxWidget.didUpdateWidget**  
   Si cambiaba la **instancia** del notifier (mismo tipo, otra instancia) no se hacía `removeListener` del viejo ni `addListener` del nuevo. Esto provocaba que el notifier viejo seguía referenciando al State y el nuevo no se escuchaba.
### Enfoque de la solución
Dejar de usar el **widget como clave única** para el state de StateWidget. En su lugar:
- Saber **qué elemento está construyendo ahora** (stack de build).
- Tener un **registro de elementos montados** indexado por **elemento**, no por widget, para poder resolver `state` cuando el stack está vacío (p. ej. en el builder de un hijo) y limpiar en unmount sin afectar a otros elementos que compartan el mismo widget const.
### Cambios en `state_widget.dart`
**StateWidget ya no escribe en el Expando.** La resolución de `state` usa dos estructuras:
1. **`_buildStackByWidget`** (`Map<StateWidget, List<StateElement>>`)  
   - Representa “quién está construyendo ahora” por widget.  
   - En `build()`: al entrar se hace push en la lista de ese widget, al salir (en `finally`) se hace pop y, si la lista queda vacía, se elimina la clave del map.  
   - Soporta varios elementos con el mismo widget (const anidados): cada uno tiene su pila, el “actual” es el último de esa pila.  
   - Lookup en `_stateFromBuildStack(widget)`: O(1).
2. **`_mountedStateElements`** (`Set<StateElement>`)  
   - Registro de **elementos** montados: `add(this)` en `mount()` y `remove(this)` en `unmount()`.  
   - La clave es la identidad del **elemento**, no del widget. Varios const comparten widget pero tienen elementos distintos, al desmontar uno solo se saca ese elemento del set.  
   - No se acumula basura: en unmount se hace un solo `remove(this)`.
**Flujo del getter `state`:** primero se intenta `_stateFromBuildStack(this)` si devuelve null (p. ej. lectura desde el builder de un RxWidget), se usa `_stateFromRegistry(this)`. Si ambos fallan, se lanza un `FlutterError`.
**StateElement:** ya no escribe en el Expando en constructor ni en `update` en `unmount()` solo hace `_mountedStateElements.remove(this)`. El Expando sigue existiendo y siendo usado por ParentState.
### Cambios en `state_parent.dart`
- **unmount():** se llama a `StateElement._elements[widget] = null`.  
- **update():** se guarda `oldWidget`, se registra el nuevo widget, se llama a `super.update(newWidget)` y **después** se hace `StateElement._elements[oldWidget] = null` para no romper lecturas que aún usen el widget viejo durante la transición.
### Cambios en `rx_widget.dart`
- **didUpdateWidget:** si `oldWidget.notifier != widget.notifier` se hace `removeListener` del notifier viejo, `addListener` del nuevo y se actualiza `value` si es el mismo notifier y solo cambia el valor, solo se actualiza `value`. Así se evita leak del State y se escucha siempre al notifier correcto.
### Resumen
- **Dispose / leaks:** StateWidget deja de depender del Expando por widget para su state el registro es por elemento (Set) y se limpia en unmount. ParentState limpia el Expando en unmount y en update (orden correcto). RxWidget desconecta el notifier viejo y conecta el nuevo cuando cambia la instancia.  
- **Const y null:** al no usar el widget como clave única y al tener un registro por elemento, varios `const` pueden coexistir unmount de uno no borra el state de los demás.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced error reporting when state access fails outside the build lifecycle.
  * Fixed stream subscription management to prevent lingering connections.

* **Improvements**
  * More efficient widget update detection when notifier instances change.
  * Improved lifecycle cleanup for mounted elements during unmounts.

* **API Changes**
  * `closeStream()` return type changed to `Future<void>?` for clearer async handling.
  * Removed `hasListeners` public getter; use alternative listener tracking methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->